### PR TITLE
Disable eslint linebreak rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,7 @@ module.exports = {
     "@tanstack/query/prefer-query-object-syntax": "error",
     "@tanstack/query/stable-query-client": "error",
     "react/prop-types": "off",
+    "linebreak-style": off,
   },
   overrides: [
     {


### PR DESCRIPTION
Added eslint rule to disable linebreak-style. This fixed my issue on Windows.
resource: https://bobbyhadz.com/blog/expected-linebreaks-to-be-lf-but-found-crlf-linebreak-style-eslint#disabling-the-linebreak-style-eslint-rule

Not sure if this should just apply to my local repo on a Windows machine, or if it should be accepted and used for all.

You may choose to accept or reject this pull request upon further discussion.