### PR TITLE
Put quotes around linebreak-style value

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
     "@tanstack/query/prefer-query-object-syntax": "error",
     "@tanstack/query/stable-query-client": "error",
     "react/prop-types": "off",
-    "linebreak-style": off,
+    "linebreak-style": "off",
   },
   overrides: [
     {


### PR DESCRIPTION
In the `linebreak-style` rule, the string value `off` should be wrapped with quotations.

I did not see this until last night. I had just copied and pasted from the resource website and there was no apparent linting warning. As a result, there does not appear to be any negative effect as it is now without quotes, but the string value should be consistent with proper syntax.

Also, I hope that I have properly linked this PR with the Issue I created.