### PR TITLE
Update linebreak-style to default to unix

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
     "@tanstack/query/prefer-query-object-syntax": "error",
     "@tanstack/query/stable-query-client": "error",
     "react/prop-types": "off",
-    "linebreak-style": "off",
+    "linebreak-style": "unix",
   },
   overrides: [
     {


### PR DESCRIPTION
I made a new correction to eslint file. 🤦‍♂️The `linebreak-style` rule is now set to `unix`.

Okay, I did not realize by adding quotations around the `off` string would create an issue, but for me on Windows, the line break problem returned. So, I went to the official documentation (https://eslint.org/docs/latest/rules/linebreak-style) and there are really only two options: `unix` and `windows` (not sure where the `off` option comes from). So, I selected the `unix` option as it is the predominant line break style of our group of developers. In choosing the `unix` option, when Windows developers save a file, it will use the 'LF' line ending over Windows default of 'CRLF'.