### PR TITLE
feat(header.jsx): add preliminary styling to desktop and mobile nav menu

### DIFF
--- a/src/features/ui/Header/Header.jsx
+++ b/src/features/ui/Header/Header.jsx
@@ -21,7 +21,7 @@ export const Header = () => {
             <Link
               key={index}
               to={navLink.href}
-              className="font-body font-bold uppercase hover:text-sky-600 duration-200"
+              className="font-bold uppercase hover:text-sky-600 duration-200"
             >
               {navLink.title}
             </Link>

--- a/src/features/ui/Header/Header.jsx
+++ b/src/features/ui/Header/Header.jsx
@@ -16,12 +16,12 @@ export const Header = () => {
         </Link>
       </aside>
       <nav>
-        <div className="hidden space-x-4 lg:block">
+        <div className="hidden space-x-4 lg:flex gap-x-7 bg-sky-300 text-white rounded-full px-16 py-3">
           {navLinks.map((navLink, index) => (
             <Link
               key={index}
               to={navLink.href}
-              className="uppercase font-kalam"
+              className="font-body font-bold uppercase hover:text-sky-600 duration-200"
             >
               {navLink.title}
             </Link>
@@ -45,7 +45,7 @@ export const Header = () => {
               leaveFrom="transform opacity-100 scale-100"
               leaveTo="transform opacity-0 scale-95"
             >
-              <Menu.Items className="absolute z-20 w-32 py-2 mt-5 origin-top-right bg-[#FEF8E6] rounded-md shadow-lg right-1 ring-1 ring-gray-900/5 focus:outline-none">
+              <Menu.Items className="absolute z-20 w-32 py-2 mt-5 origin-top-right bg-sky-300 rounded-md shadow-lg right-1 ring-1 ring-gray-900/5 focus:outline-none">
                 <div className="flex flex-col">
                   {navLinks.map((navLink) => (
                     <Menu.Item key={navLink.href} as={Fragment}>
@@ -54,9 +54,9 @@ export const Header = () => {
                           to={navLink.href}
                           className={`${
                             active
-                              ? "bg-blue-500 text-white"
-                              : "bg-white text-black"
-                          }`}
+                              ? "bg-sky-400 text-white"
+                              : "bg-sky-300 text-white"
+                          } font-bold uppercase px-4`}
                         >
                           {navLink.title}
                         </Link>


### PR DESCRIPTION
This is my first go at styling the nav menu for desktop and mobile, to at least look somewhat representative of the design. 
More needs to be done with design recommendations.