### PR TITLE
fix(global.css): increase heading brightness

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,9 +104,11 @@
 
 .text-shadow {
   text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+  filter: brightness(1.25);
 }
 .text-shadow-sm {
   text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.25);
+  filter: brightness(1.25);
 }
 
 .text-stroke {
@@ -119,9 +121,11 @@
 @media screen and (min-width: 1080px) {
   .text-shadow {
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    filter: brightness(1.25);
   }
   .text-shadow-sm {
     text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+    filter: brightness(1.25);
   }
 
   .text-stroke {


### PR DESCRIPTION
The text shadow on headings with transparent text and gradient backgrounds darkened the text 25%. This simple fix adds a css brightness filter to offseet this effect.