### PR TITLE
fix(fetchrecipes): wrap localStorage.setItem in try/catch block

### DIFF
--- a/src/api/recipes.js
+++ b/src/api/recipes.js
@@ -31,10 +31,14 @@ export async function fetchRecipes(search, from = 0, size = 20) {
         params: { from, size, q: search },
       },
     );
-    localStorage.setItem(
-      `${search}-searchRecipeResults`,
-      JSON.stringify(data.results),
-    );
+    try {
+      localStorage.setItem(
+        `${search}-searchRecipeResults`,
+        JSON.stringify(data.results),
+      );
+    } catch (error) {
+      console.error("Could not write to local storage:", error);
+    }
     return data;
   } catch (error) {
     console.error(error);

--- a/src/mirageServer/server.js
+++ b/src/mirageServer/server.js
@@ -34,7 +34,8 @@ export default function () {
   }
 
   function matchSearchId(q, data) {
-    const id = q.match(/(?<=id:)[0-9]+/i);
+    const idMatch = q.match(/(?:id:)([0-9]+)/i);
+    const id = idMatch && idMatch[1];
     if (!id) return false;
     const result = data.results.find((recipe) => recipe.id === +id);
     if (!result) return false;


### PR DESCRIPTION
Search was failing on iOS and occasionally on desktop when the data exceeded the local storage quota. There were two separate issues:

1. Wrapping the localStorage.setItem call in a try/catch block allows the write to fail gracefully without interrupting the display of search results.
2. There was a regex in the Mirage server that used lookahead syntax not supported by Safari. Replacing this with capturing group syntax solved this issue.

CH-100